### PR TITLE
Restore classic Join and Merge handlers, make index-based handlers optional

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align/resources/main/help/join.xhtml
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/resources/main/help/join.xhtml
@@ -42,6 +42,19 @@
 		</div>
 		<p>To create a condition, select a property on the left and on the
 			right side, then click on the button in the middle.</p>
+			
+		<h2>
+			<a name="condition">Index Join Handler (experimental)</a>
+		</h2>
+		<p>
+			To activate the use of the Index Join Handler for all Join and Groovy
+			Join transformations, set the Java system property <code>hale.functions.use_index_join_handler</code>
+			or the environment variable <code>HALE_FUNCTIONS_USE_INDEX_JOIN_HANDLER</code>.
+		</p>
+		<p>
+			The Index Join Handler is experimental and can potentially have a
+			negative impact on the performance of Join and Groovy Join transformations.
+		</p>
 	</div>
 </body>
 </html>

--- a/common/plugins/eu.esdihumboldt.hale.common.align/resources/main/help/merge/help.xhtml
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/resources/main/help/merge/help.xhtml
@@ -20,6 +20,20 @@
 	</br>
 		<img src="../../eu.esdihumboldt.hale.common.align/help/merge/mergeAggregate.png" />
 	</p>
+
+	<h2>
+		<a name="condition">Index Merge Handler (experimental)</a>
+	</h2>
+	<p>
+		To activate the use of the Index Merge Handler for all Merge and Groovy
+		Merge transformations, set the Java system property <code>hale.functions.use_index_merge_handler</code>
+		or the environment variable <code>HALE_FUNCTIONS_USE_INDEX_MERGE_HANDLER</code>.
+	</p>
+	<p>
+		The Index Merge Handler is experimental and can potentially have a
+		negative impact on the performance of Merge and Groovy Merge transformations.
+	</p>
+	
 </div>
 </body>
 </html>

--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/Join.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/Join.java
@@ -17,7 +17,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.cst.functions.core.join.IndexJoinHandler;
+import eu.esdihumboldt.cst.functions.core.join.JoinHandler;
 import eu.esdihumboldt.hale.common.align.model.Cell;
 import eu.esdihumboldt.hale.common.align.model.functions.JoinFunction;
 import eu.esdihumboldt.hale.common.align.model.functions.join.JoinParameter;
@@ -36,11 +39,32 @@ import eu.esdihumboldt.hale.common.instance.index.InstanceIndexContribution;
 public class Join extends Retype implements JoinFunction, InstanceIndexContribution {
 
 	/**
+	 * The log
+	 */
+	private static final ALogger LOG = ALoggerFactory.getLogger(Join.class);
+
+	/**
 	 * @see eu.esdihumboldt.hale.common.align.transformation.function.impl.AbstractTypeTransformation#getInstanceHandler()
 	 */
 	@Override
 	public InstanceHandler<? super TransformationEngine> getInstanceHandler() {
-		return new IndexJoinHandler();
+		boolean useIndexJoinHandler = false;
+
+		String setting = System.getProperty("hale.functions.join.use_index_join_handler");
+
+		if (setting == null) {
+			setting = System.getenv("HALE_FUNCTIONS_USE_INDEX_JOIN_HANDLER");
+		}
+
+		if (setting != null) {
+			try {
+				useIndexJoinHandler = Boolean.valueOf(setting);
+			} catch (Throwable e) {
+				LOG.error("Error applying index join handler setting: " + setting, e);
+			}
+		}
+
+		return useIndexJoinHandler ? new IndexJoinHandler() : new JoinHandler();
 	}
 
 	/**

--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/Merge.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/Merge.java
@@ -16,7 +16,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.cst.functions.core.merge.IndexMergeHandler;
+import eu.esdihumboldt.cst.functions.core.merge.PropertiesMergeHandler;
 import eu.esdihumboldt.hale.common.align.model.Cell;
 import eu.esdihumboldt.hale.common.align.model.functions.MergeFunction;
 import eu.esdihumboldt.hale.common.align.model.functions.merge.MergeUtil;
@@ -34,11 +37,32 @@ import eu.esdihumboldt.hale.common.instance.index.InstanceIndexContribution;
 public class Merge extends Retype implements MergeFunction, InstanceIndexContribution {
 
 	/**
+	 * The log
+	 */
+	private static final ALogger LOG = ALoggerFactory.getLogger(Merge.class);
+
+	/**
 	 * @see eu.esdihumboldt.hale.common.align.transformation.function.impl.AbstractTypeTransformation#getInstanceHandler()
 	 */
 	@Override
 	public InstanceHandler<? super TransformationEngine> getInstanceHandler() {
-		return new IndexMergeHandler();
+		boolean useIndexMergeHandler = false;
+
+		String setting = System.getProperty("hale.functions.use_index_merge_handler");
+
+		if (setting == null) {
+			setting = System.getenv("HALE_FUNCTIONS_USE_INDEX_MERGE_HANDLER");
+		}
+
+		if (setting != null) {
+			try {
+				useIndexMergeHandler = Boolean.valueOf(setting);
+			} catch (Throwable e) {
+				LOG.error("Error applying index merge handler setting: " + setting, e);
+			}
+		}
+
+		return useIndexMergeHandler ? new IndexMergeHandler() : new PropertiesMergeHandler();
 	}
 
 	/**

--- a/cst/plugins/eu.esdihumboldt.cst.functions.groovy/src/eu/esdihumboldt/cst/functions/groovy/GroovyJoin.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.groovy/src/eu/esdihumboldt/cst/functions/groovy/GroovyJoin.java
@@ -15,8 +15,11 @@ package eu.esdihumboldt.cst.functions.groovy;
 import java.util.Collection;
 import java.util.List;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.cst.functions.core.Join;
 import eu.esdihumboldt.cst.functions.core.join.IndexJoinHandler;
+import eu.esdihumboldt.cst.functions.core.join.JoinHandler;
 import eu.esdihumboldt.hale.common.align.model.Cell;
 import eu.esdihumboldt.hale.common.align.model.functions.JoinFunction;
 import eu.esdihumboldt.hale.common.align.model.impl.PropertyEntityDefinition;
@@ -35,6 +38,11 @@ import eu.esdihumboldt.hale.common.instance.index.InstanceIndexContribution;
 public class GroovyJoin extends GroovyRetype implements JoinFunction, InstanceIndexContribution {
 
 	/**
+	 * The log
+	 */
+	private static final ALogger LOG = ALoggerFactory.getLogger(GroovyJoin.class);
+
+	/**
 	 * The function ID. Not named <code>ID</code> to avoid shadowing
 	 * {@link JoinFunction#ID}.
 	 */
@@ -47,7 +55,23 @@ public class GroovyJoin extends GroovyRetype implements JoinFunction, InstanceIn
 
 	@Override
 	public InstanceHandler<? super TransformationEngine> getInstanceHandler() {
-		return new IndexJoinHandler();
+		boolean useIndexJoinHandler = false;
+
+		String setting = System.getProperty("hale.functions.use_index_join_handler");
+
+		if (setting == null) {
+			setting = System.getenv("HALE_FUNCTIONS_USE_INDEX_JOIN_HANDLER");
+		}
+
+		if (setting != null) {
+			try {
+				useIndexJoinHandler = Boolean.valueOf(setting);
+			} catch (Throwable e) {
+				LOG.error("Error applying index join handler setting: " + setting, e);
+			}
+		}
+
+		return useIndexJoinHandler ? new IndexJoinHandler() : new JoinHandler();
 	}
 
 	/**

--- a/cst/plugins/eu.esdihumboldt.cst.functions.groovy/src/eu/esdihumboldt/cst/functions/groovy/GroovyMerge.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.groovy/src/eu/esdihumboldt/cst/functions/groovy/GroovyMerge.java
@@ -15,8 +15,11 @@ package eu.esdihumboldt.cst.functions.groovy;
 import java.util.Collection;
 import java.util.List;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.cst.functions.core.Merge;
 import eu.esdihumboldt.cst.functions.core.merge.IndexMergeHandler;
+import eu.esdihumboldt.cst.functions.core.merge.PropertiesMergeHandler;
 import eu.esdihumboldt.hale.common.align.model.Cell;
 import eu.esdihumboldt.hale.common.align.model.functions.MergeFunction;
 import eu.esdihumboldt.hale.common.align.model.impl.PropertyEntityDefinition;
@@ -35,6 +38,11 @@ import eu.esdihumboldt.hale.common.instance.index.InstanceIndexContribution;
 public class GroovyMerge extends GroovyRetype implements MergeFunction, InstanceIndexContribution {
 
 	/**
+	 * The log
+	 */
+	private static final ALogger LOG = ALoggerFactory.getLogger(GroovyMerge.class);
+
+	/**
 	 * The function ID. Not named <code>ID</code> to avoid shadowing
 	 * {@link MergeFunction#ID}.
 	 */
@@ -47,7 +55,23 @@ public class GroovyMerge extends GroovyRetype implements MergeFunction, Instance
 
 	@Override
 	public InstanceHandler<? super TransformationEngine> getInstanceHandler() {
-		return new IndexMergeHandler();
+		boolean useIndexMergeHandler = false;
+
+		String setting = System.getProperty("hale.functions.use_index_merge_handler");
+
+		if (setting == null) {
+			setting = System.getenv("HALE_FUNCTIONS_USE_INDEX_MERGE_HANDLER");
+		}
+
+		if (setting != null) {
+			try {
+				useIndexMergeHandler = Boolean.valueOf(setting);
+			} catch (Throwable e) {
+				LOG.error("Error applying index merge handler setting: " + setting, e);
+			}
+		}
+
+		return useIndexMergeHandler ? new IndexMergeHandler() : new PropertiesMergeHandler();
 	}
 
 	/**


### PR DESCRIPTION
Restore the classes `JoinHandler` and `PropertiesMergeHandler` as the default handlers for the transformation functions Join, Groovy Join, Merge and Groovy Merge.

The previous default handlers `IndexJoinHandler` and `IndexMergeHandler` have demonstrated negative impact on the performance of some transformations. Until this is better understood and fixed, these handlers are now optional and can be activated via the following Java properties and environment variables:

- Join/Groovy Join: `hale.functions.use_index_join_handler` / `HALE_FUNCTIONS_USE_INDEX_JOIN_HANDLER`
- Merge/Groovy Merge: `hale.functions.use_index_merge_handler` / `HALE_FUNCTIONS_USE_INDEX_MERGE_HANDLER`

ING-4464